### PR TITLE
Fix missing headers include

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,5 +1,7 @@
 #include <tree_sitter/parser.h>
 #include <string>
+#include <cwchar>
+#include <cwctype>
 
 namespace {
 


### PR DESCRIPTION
There are missing headers that should be included in `src/scanner.cc`.